### PR TITLE
[STEP-3] 콘서트 조회, 예약/결제 기능, 포인트 충전 기능 구현

### DIFF
--- a/src/main/java/com/roovies/concertreservation/payments/application/dto/command/PayReservationCommand.java
+++ b/src/main/java/com/roovies/concertreservation/payments/application/dto/command/PayReservationCommand.java
@@ -1,0 +1,30 @@
+package com.roovies.concertreservation.payments.application.dto.command;
+
+import java.util.List;
+
+public record PayReservationCommand(
+        String idempotencyKey,
+        Long scheduleId,
+        List<Long> seatIds,
+        Long userId,
+        Long payForAmount,
+        Long discountAmount
+) {
+    public static PayReservationCommand of(
+            String idempotencyKey,
+            Long scheduleId,
+            List<Long> seatIds,
+            Long userId,
+            Long payForAmount,
+            Long discountAmount
+    ) {
+        return new PayReservationCommand(
+                idempotencyKey,
+                scheduleId,
+                seatIds,
+                userId,
+                payForAmount,
+                discountAmount
+        );
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/application/dto/result/PayReservationResult.java
+++ b/src/main/java/com/roovies/concertreservation/payments/application/dto/result/PayReservationResult.java
@@ -1,0 +1,23 @@
+package com.roovies.concertreservation.payments.application.dto.result;
+
+import com.roovies.concertreservation.payments.domain.enums.PaymentStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record PayReservationResult(
+        Long paymentId,
+        Long scheduleId,
+        List<Long> seatIds,
+        Long userId,
+        Long originalAmount,
+        Long discountAmount,
+        Long paidAmount,
+        PaymentStatus status,
+        LocalDateTime completedAt
+) {
+    public static PayReservationResult of(Long paymentId, Long scheduleId, List<Long> seatIds, Long userId, Long originalAmount, Long discountAmount, Long paidAmount, PaymentStatus status, LocalDateTime completedAt) {
+        return new PayReservationResult(paymentId, scheduleId, seatIds, userId, originalAmount, discountAmount, paidAmount, status, completedAt);
+
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/application/port/in/PayReservationUseCase.java
+++ b/src/main/java/com/roovies/concertreservation/payments/application/port/in/PayReservationUseCase.java
@@ -1,0 +1,8 @@
+package com.roovies.concertreservation.payments.application.port.in;
+
+import com.roovies.concertreservation.payments.application.dto.command.PayReservationCommand;
+import com.roovies.concertreservation.payments.application.dto.result.PayReservationResult;
+
+public interface PayReservationUseCase {
+    PayReservationResult execute(PayReservationCommand command);
+}

--- a/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentIdempotencyRepositoryPort.java
+++ b/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentIdempotencyRepositoryPort.java
@@ -1,0 +1,13 @@
+package com.roovies.concertreservation.payments.application.port.out;
+
+import com.roovies.concertreservation.payments.application.dto.result.PayReservationResult;
+import com.roovies.concertreservation.payments.domain.entity.PaymentIdempotency;
+
+import java.util.Optional;
+
+public interface PaymentIdempotencyRepositoryPort {
+    boolean tryLock(PaymentIdempotency paymentIdempotency);
+    Optional<PaymentIdempotency> findByKey(String key);
+    void setResult(PaymentIdempotency idempotency, Long paymentId, String result);
+    void setFailed(PaymentIdempotency idempotency, String reason);
+}

--- a/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentPointQueryPort.java
+++ b/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentPointQueryPort.java
@@ -1,0 +1,5 @@
+package com.roovies.concertreservation.payments.application.port.out;
+
+public interface PaymentPointQueryPort {
+    Long getUserPoints(Long userId);
+}

--- a/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentRepositoryPort.java
+++ b/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentRepositoryPort.java
@@ -1,0 +1,8 @@
+package com.roovies.concertreservation.payments.application.port.out;
+
+import com.roovies.concertreservation.payments.domain.entity.Payment;
+
+public interface PaymentRepositoryPort {
+
+    Payment save(Payment payment);
+}

--- a/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentReservationQueryPort.java
+++ b/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentReservationQueryPort.java
@@ -1,0 +1,8 @@
+package com.roovies.concertreservation.payments.application.port.out;
+
+import com.roovies.concertreservation.payments.domain.external.query.HeldSeatsQuery;
+import com.roovies.concertreservation.payments.domain.external.snapshot.PaymentHeldSeatsSnapShot;
+
+public interface PaymentReservationQueryPort {
+    PaymentHeldSeatsSnapShot findHeldSeats(HeldSeatsQuery query);
+}

--- a/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentUserGatewayPort.java
+++ b/src/main/java/com/roovies/concertreservation/payments/application/port/out/PaymentUserGatewayPort.java
@@ -1,0 +1,7 @@
+package com.roovies.concertreservation.payments.application.port.out;
+
+public interface PaymentUserGatewayPort {
+
+    void updateUserPoints(Long userId, Long points);
+
+}

--- a/src/main/java/com/roovies/concertreservation/payments/application/service/PayReservationService.java
+++ b/src/main/java/com/roovies/concertreservation/payments/application/service/PayReservationService.java
@@ -1,0 +1,167 @@
+package com.roovies.concertreservation.payments.application.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.roovies.concertreservation.payments.application.dto.command.PayReservationCommand;
+import com.roovies.concertreservation.payments.application.dto.result.PayReservationResult;
+import com.roovies.concertreservation.payments.application.port.in.PayReservationUseCase;
+import com.roovies.concertreservation.payments.application.port.out.*;
+import com.roovies.concertreservation.payments.domain.entity.Payment;
+import com.roovies.concertreservation.payments.domain.entity.PaymentIdempotency;
+import com.roovies.concertreservation.payments.domain.external.query.HeldSeatsQuery;
+import com.roovies.concertreservation.payments.domain.external.snapshot.PaymentHeldSeatsSnapShot;
+import com.roovies.concertreservation.shared.domain.vo.Amount;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class PayReservationService implements PayReservationUseCase {
+
+    private final PaymentRepositoryPort paymentRepositoryPort;
+    private final PaymentIdempotencyRepositoryPort paymentIdempotencyRepositoryPort;
+
+    private final PaymentReservationQueryPort paymentReservationQueryPort;
+    private final PaymentPointQueryPort paymentPointQueryPort;
+    private final PaymentUserGatewayPort paymentUserGatewayPort;
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public PayReservationResult execute(PayReservationCommand command) {
+        HeldSeatsQuery query = HeldSeatsQuery.of(
+                command.scheduleId(),
+                command.seatIds(),
+                command.userId()
+        );
+
+        PaymentHeldSeatsSnapShot heldSeats = paymentReservationQueryPort.findHeldSeats(query);
+        if (heldSeats.seatIds().isEmpty())
+            throw new IllegalStateException("예약 대기 중인 좌석이 없습니다.");
+
+        // 멱등성 처리
+        PaymentIdempotency idempotency = PaymentIdempotency.tryProcess(
+                command.idempotencyKey(),
+                command.userId()
+        );
+
+        // 멱등성 키 선점 시도 (RDB INSERT)
+        boolean lockAquired = paymentIdempotencyRepositoryPort.tryLock(idempotency);
+        if (!lockAquired)
+            return handleDuplicateRequest(command.idempotencyKey());
+
+        // 락 획득한 경우 결제 로직 수행
+        try {
+            Payment result = processPayment(command, heldSeats);
+            // 결과 객체 생성
+            PayReservationResult payReservationResult = PayReservationResult.of(
+                    result.getId(),
+                    command.scheduleId(),
+                    command.seatIds(),
+                    command.userId(),
+                    result.getOriginalAmount().value(),
+                    result.getDiscountAmount().value(),
+                    result.getPaidAmount().value(),
+                    result.getStatus(),
+                    result.getCreatedAt()
+            );
+
+            // 성공한 경우 멱등성 정보 갱신
+            paymentIdempotencyRepositoryPort.setResult(idempotency, result.getId(), objectMapper.writeValueAsString(payReservationResult));
+            return payReservationResult;
+
+        } catch (IllegalStateException e) {
+            // 비즈니스 로직 실패 (포인트 부족, 좌석 없음 등)
+            log.warn("결제 비즈니스 로직 실패: idempotencyKey={}, reason={}",
+                    idempotency.getKey(), e.getMessage());
+            paymentIdempotencyRepositoryPort.setFailed(idempotency, e.getMessage());
+            throw e;
+
+        } catch (Exception e) {
+            // 예상치 못한 기술적 실패
+            log.error("결제 처리 중 예상치 못한 오류: idempotencyKey={}", idempotency.getKey(), e);
+            paymentIdempotencyRepositoryPort.setFailed(idempotency, "시스템 오류");
+            throw new RuntimeException("결제 처리에 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * 중복 요청 처리 로직
+     */
+    private PayReservationResult handleDuplicateRequest(String idempotencyKey) {
+        PaymentIdempotency storedIdempotency = paymentIdempotencyRepositoryPort.findByKey(idempotencyKey)
+                .orElseThrow(() -> new IllegalArgumentException("동시성 문제가 발생했습니다."));
+
+        if (storedIdempotency.isProcessing()) {
+            throw new IllegalArgumentException("중복된 요청입니다. 처리 중입니다.");
+        }
+
+        if (storedIdempotency.isSuccess()) {
+            return deserializeResult(storedIdempotency);
+        }
+
+        // 실패 상태인 경우
+        throw new IllegalArgumentException("이전 요청이 실패했습니다. 새로운 멱등성 키로 다시 시도해주세요.");
+    }
+
+    /**
+     * 저장된 결과를 PayReservationResult로 역직렬화
+     */
+    private PayReservationResult deserializeResult(PaymentIdempotency idempotency) {
+        if (idempotency.getResultData() == null || idempotency.getResultData().trim().isEmpty()) {
+            log.error("No result data found for successful idempotency. key: {}", idempotency.getKey());
+            throw new NoSuchElementException("저장된 결제 결과를 찾을 수 없습니다.");
+        }
+
+        try {
+            PayReservationResult result = objectMapper.readValue(
+                    idempotency.getResultData(),
+                    PayReservationResult.class
+            );
+
+            log.debug("Successfully deserialized result for idempotencyKey: {}", idempotency.getKey());
+            return result;
+
+        } catch (JsonProcessingException e) {
+            log.error("Failed to deserialize payment result for idempotencyKey: {}", idempotency.getKey(), e);
+            throw new RuntimeException("저장된 결제 결과를 읽는데 실패했습니다.", e);
+        }
+    }
+
+    /**
+     * 실제 결제 처리 로직
+     */
+    private Payment processPayment(PayReservationCommand command, PaymentHeldSeatsSnapShot heldSeats) {
+        // 실제 보유 포인트 조회 및 결제 가능한지 검증
+        Long currentPoint = paymentPointQueryPort.getUserPoints(command.userId());
+        if (currentPoint < heldSeats.totalPrice())
+            throw new IllegalStateException("결제 금액이 부족합니다.");
+
+        // 결제 객체 만들기
+        Payment payment = Payment.create(
+                command.userId(),
+                Amount.of(heldSeats.totalPrice()),
+                Amount.of(command.payForAmount())
+        );
+
+        // 할인 금액 있으면 적용
+        if (command.discountAmount() > 0)
+            payment.discount(Amount.of(command.discountAmount()));
+
+        // 최종 결제 후 남은 포인트 계산
+        Long remainingAmount = currentPoint - payment.getPaidAmount().value();
+
+        // 결제 정보 저장
+        Payment result = paymentRepositoryPort.save(payment);
+
+        // 남은 포인트 반영
+        paymentUserGatewayPort.updateUserPoints(command.userId(), remainingAmount);
+        return result;
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/domain/entity/Payment.java
+++ b/src/main/java/com/roovies/concertreservation/payments/domain/entity/Payment.java
@@ -1,0 +1,79 @@
+package com.roovies.concertreservation.payments.domain.entity;
+
+import com.roovies.concertreservation.payments.domain.enums.PaymentStatus;
+import com.roovies.concertreservation.shared.domain.vo.Amount;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class Payment {
+    private final Long id;
+    private final Amount originalAmount;
+    private Amount discountAmount;
+    private Amount paidAmount;
+    private PaymentStatus status;
+    private final LocalDateTime createdAt;
+
+    public static Payment create(Long id, Amount originalAmount, Amount paidAmount) {
+        return new Payment(id, originalAmount, paidAmount, PaymentStatus.SUCCESS);
+    }
+
+    public static Payment restore(Long id, Amount originalAmount, Amount discountAmount, Amount paidAmount, PaymentStatus status, LocalDateTime createdAt) {
+        return new Payment(id, originalAmount, discountAmount, paidAmount, status, createdAt);
+    }
+
+    private Payment(Long id, Amount originalAmount, Amount paidAmount, PaymentStatus status) {
+        this.id = id;
+        this.originalAmount = originalAmount;
+        this.paidAmount = paidAmount;
+        this.status = status;
+        this.createdAt = LocalDateTime.now();
+
+        validateAmount();
+    }
+
+    private Payment(Long id, Amount originalAmount, Amount discountAmount, Amount paidAmount, PaymentStatus status, LocalDateTime createdAt) {
+        this.id = id;
+        this.originalAmount = originalAmount;
+        this.discountAmount = discountAmount;
+        this.paidAmount = paidAmount;
+        this.status = status;
+        this.createdAt = createdAt;
+        validateAmount();
+    }
+
+    private void validateAmount() {
+        validateOriginalAmount();
+        validatePaidAmount();
+    }
+
+    private void validateOriginalAmount() {
+        if (this.originalAmount == null)
+            throw new IllegalArgumentException("정가는 null일 수 없습니다.");
+
+        if (this.originalAmount.value() % 100 != 0)
+            throw new IllegalArgumentException("정가는 100원 단위어야 합니다.");
+    }
+
+    private void validatePaidAmount() {
+        if (this.paidAmount == null)
+            throw new IllegalArgumentException("결제 금액은 null일 수 없습니다.");
+
+        if (this.paidAmount.value() == 0)
+            throw new IllegalArgumentException("결제 금액은 0원일 수 없습니다.");
+
+        if (this.paidAmount.value() % 100 != 0)
+            throw new IllegalArgumentException("결제 금액은 100원 단위어야 합니다.");
+
+        if (this.originalAmount.value() < this.paidAmount.value())
+            throw new IllegalArgumentException("결제 금액이 정가보다 많습니다.");
+    }
+
+    public void discount(Amount discountAmount) {
+        this.discountAmount = discountAmount;
+        this.paidAmount = this.paidAmount.subtract(discountAmount);
+    }
+
+
+}

--- a/src/main/java/com/roovies/concertreservation/payments/domain/entity/PaymentIdempotency.java
+++ b/src/main/java/com/roovies/concertreservation/payments/domain/entity/PaymentIdempotency.java
@@ -1,0 +1,70 @@
+package com.roovies.concertreservation.payments.domain.entity;
+
+import com.roovies.concertreservation.payments.domain.enums.PaymentIdempotencyStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class PaymentIdempotency {
+    private final String key;
+    private final Long userId;
+    private Long paymentId; // 결제 완료 시 설정
+    private PaymentIdempotencyStatus status;
+    private String resultData; // JSON으로 직렬화된 결과
+    private final LocalDateTime createdAt;
+    private LocalDateTime completedAt;
+
+    public static PaymentIdempotency tryProcess(String key, Long userId) {
+        return new PaymentIdempotency(
+                key,
+                userId,
+                null,
+                PaymentIdempotencyStatus.PROCESSING,
+                null,
+                LocalDateTime.now(),
+                null
+        );
+    }
+
+    public static PaymentIdempotency create(String key, Long userId, Long paymentId,
+                                            PaymentIdempotencyStatus status, String resultData,
+                                            LocalDateTime createdAt, LocalDateTime completedAt) {
+        return new PaymentIdempotency(
+                key,
+                userId,
+                paymentId,
+                status,
+                resultData,
+                createdAt,
+                completedAt
+        );
+    }
+
+    private PaymentIdempotency(String key, Long userId, Long paymentId,
+                               PaymentIdempotencyStatus status, String resultData,
+                               LocalDateTime createdAt, LocalDateTime completedAt) {
+        this.key = key;
+        this.userId = userId;
+        this.paymentId = paymentId;
+        this.status = status;
+        this.resultData = resultData;
+        this.createdAt = createdAt;
+        this.completedAt = completedAt;
+    }
+
+    public boolean isProcessing() {
+        return this.status == PaymentIdempotencyStatus.PROCESSING;
+    }
+
+    public boolean isSuccess() {
+        return this.status == PaymentIdempotencyStatus.SUCCESS;
+    }
+
+    public void setResult(Long paymentId, String resultData) {
+        this.paymentId = paymentId;
+        this.resultData = resultData;
+        this.status = PaymentIdempotencyStatus.SUCCESS;
+        this.completedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/domain/enums/PaymentIdempotencyStatus.java
+++ b/src/main/java/com/roovies/concertreservation/payments/domain/enums/PaymentIdempotencyStatus.java
@@ -1,0 +1,7 @@
+package com.roovies.concertreservation.payments.domain.enums;
+
+public enum PaymentIdempotencyStatus {
+    PROCESSING,
+    SUCCESS,
+    FAILED
+}

--- a/src/main/java/com/roovies/concertreservation/payments/domain/external/query/HeldSeatsQuery.java
+++ b/src/main/java/com/roovies/concertreservation/payments/domain/external/query/HeldSeatsQuery.java
@@ -1,0 +1,13 @@
+package com.roovies.concertreservation.payments.domain.external.query;
+
+import java.util.List;
+
+public record HeldSeatsQuery(
+        Long scheduleId,
+        List<Long> seatIds,
+        Long userId
+) {
+    public static HeldSeatsQuery of(Long scheduleId, List<Long> seatIds, Long userId) {
+        return new HeldSeatsQuery(scheduleId, seatIds, userId);
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/domain/external/snapshot/PaymentHeldSeatsSnapShot.java
+++ b/src/main/java/com/roovies/concertreservation/payments/domain/external/snapshot/PaymentHeldSeatsSnapShot.java
@@ -1,0 +1,14 @@
+package com.roovies.concertreservation.payments.domain.external.snapshot;
+
+import java.util.List;
+
+public record PaymentHeldSeatsSnapShot(
+        Long scheduleId,
+        List<Long> seatIds,
+        Long userId,
+        Long totalPrice
+) {
+    public static PaymentHeldSeatsSnapShot of(Long scheduleId, List<Long> seatIds, Long userId, Long totalPrice) {
+        return new PaymentHeldSeatsSnapShot(scheduleId, seatIds, userId, totalPrice);
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/external/PaymentPointQueryAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/external/PaymentPointQueryAdapter.java
@@ -1,0 +1,18 @@
+package com.roovies.concertreservation.payments.infra.adapter.out.external;
+
+import com.roovies.concertreservation.payments.application.port.out.PaymentPointQueryPort;
+import com.roovies.concertreservation.points.application.port.in.GetPointUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentPointQueryAdapter implements PaymentPointQueryPort {
+
+    private final GetPointUseCase getPointUseCase;
+
+    @Override
+    public Long getUserPoints(Long userId) {
+        return getPointUseCase.execute(userId);
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/external/PaymentReservationQueryAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/external/PaymentReservationQueryAdapter.java
@@ -1,0 +1,36 @@
+package com.roovies.concertreservation.payments.infra.adapter.out.external;
+
+import com.roovies.concertreservation.payments.application.port.out.PaymentReservationQueryPort;
+import com.roovies.concertreservation.payments.domain.external.query.HeldSeatsQuery;
+import com.roovies.concertreservation.payments.domain.external.snapshot.PaymentHeldSeatsSnapShot;
+import com.roovies.concertreservation.reservations.application.dto.query.GetHeldSeatsQuery;
+import com.roovies.concertreservation.reservations.application.dto.result.HoldSeatResult;
+import com.roovies.concertreservation.reservations.application.port.in.GetHeldSeatsUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+@Component
+@RequiredArgsConstructor
+public class PaymentReservationQueryAdapter implements PaymentReservationQueryPort {
+
+    private final GetHeldSeatsUseCase getHeldSeatsUseCase;
+
+    @Override
+    public PaymentHeldSeatsSnapShot findHeldSeats(HeldSeatsQuery query) {
+
+        GetHeldSeatsQuery externalQuery = GetHeldSeatsQuery.builder()
+                .scheduleId(query.scheduleId())
+                .seatIds(query.seatIds())
+                .userId(query.userId())
+                .build();
+
+        HoldSeatResult result = getHeldSeatsUseCase.execute(externalQuery);
+        return PaymentHeldSeatsSnapShot.of(
+                result.scheduleId(),
+                result.seatIds(),
+                result.userId(),
+                result.totalPrice()
+        );
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/external/PaymentUserGatewayAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/external/PaymentUserGatewayAdapter.java
@@ -1,0 +1,21 @@
+package com.roovies.concertreservation.payments.infra.adapter.out.external;
+
+import com.roovies.concertreservation.payments.application.port.out.PaymentUserGatewayPort;
+import com.roovies.concertreservation.users.application.port.in.UpdateUserPointUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentUserGatewayAdapter implements PaymentUserGatewayPort {
+
+    private final UpdateUserPointUseCase updateUserPointUseCase;
+
+
+
+
+    @Override
+    public void updateUserPoints(Long userId, Long points) {
+        // TODO: 기능 구현 필요
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/PaymentIdempotencyJpaRepository.java
+++ b/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/PaymentIdempotencyJpaRepository.java
@@ -1,0 +1,7 @@
+package com.roovies.concertreservation.payments.infra.adapter.out.persistence;
+
+import com.roovies.concertreservation.payments.infra.adapter.out.persistence.entity.PaymentIdempotencyJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentIdempotencyJpaRepository extends JpaRepository<PaymentIdempotencyJpaEntity, String> {
+}

--- a/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/PaymentIdempotencyRepositoryAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/PaymentIdempotencyRepositoryAdapter.java
@@ -1,0 +1,80 @@
+package com.roovies.concertreservation.payments.infra.adapter.out.persistence;
+
+import com.roovies.concertreservation.payments.application.port.out.PaymentIdempotencyRepositoryPort;
+import com.roovies.concertreservation.payments.domain.entity.PaymentIdempotency;
+import com.roovies.concertreservation.payments.infra.adapter.out.persistence.entity.PaymentIdempotencyJpaEntity;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class PaymentIdempotencyRepositoryAdapter implements PaymentIdempotencyRepositoryPort {
+
+    private final PaymentIdempotencyJpaRepository paymentIdempotencyJpaRepository;
+
+    @Override
+    public boolean tryLock(PaymentIdempotency paymentIdempotency) {
+        try {
+            PaymentIdempotencyJpaEntity entity = PaymentIdempotencyJpaEntity.from(paymentIdempotency);
+            paymentIdempotencyJpaRepository.save(entity);
+            log.info("멱등성 키 처리 시작: idempotencyKey={}", paymentIdempotency.getKey());
+            return true;
+
+        } catch (DataIntegrityViolationException e) {
+            // 중복 키 - 이미 처리 중이거나 완료
+            log.info("중복 멱등성 키 감지: idempotencyKey={}", paymentIdempotency.getKey());
+            return false;
+        }
+    }
+
+    @Override
+    public Optional<PaymentIdempotency> findByKey(String key) {
+        Optional<PaymentIdempotencyJpaEntity> entity = paymentIdempotencyJpaRepository.findById(key);
+        if (entity.isPresent()) {
+            PaymentIdempotencyJpaEntity idempotencyJpaEntity = entity.get();
+            return Optional.of(
+                    PaymentIdempotency.create(
+                            idempotencyJpaEntity.getKey(),
+                            idempotencyJpaEntity.getUserId(),
+                            idempotencyJpaEntity.getPaymentId(),
+                            idempotencyJpaEntity.getStatus(),
+                            idempotencyJpaEntity.getResultData(),
+                            idempotencyJpaEntity.getCreatedAt(),
+                            idempotencyJpaEntity.getCompletedAt()
+                    )
+            );
+        }
+
+        return Optional.empty();
+    }
+
+    @Override
+    public void setResult(PaymentIdempotency idempotency, Long paymentId, String result) {
+        // 멱등성 엔티티 업데이트
+        PaymentIdempotencyJpaEntity entity = paymentIdempotencyJpaRepository.findById(idempotency.getKey())
+                .orElseThrow(() -> new IllegalArgumentException("멱등성 키를 찾을 수 없습니다: " + idempotency.getKey()));
+
+        entity.updateResult(paymentId, result);
+
+        paymentIdempotencyJpaRepository.save(entity);
+        log.info("멱등성 키 처리 완료: idempotencyKey={}, paymentId={}",
+                idempotency.getKey(), paymentId);
+    }
+
+    @Override
+    public void setFailed(PaymentIdempotency idempotency, String failureReason) {
+        PaymentIdempotencyJpaEntity entity = paymentIdempotencyJpaRepository.findById(idempotency.getKey())
+                .orElseThrow(() -> new IllegalArgumentException("멱등성 키를 찾을 수 없습니다: " + idempotency.getKey()));
+
+        entity.updateFailed(failureReason);
+
+        paymentIdempotencyJpaRepository.save(entity);
+        log.warn("멱등성 키 처리 실패: idempotencyKey={}, reason={}",
+                idempotency.getKey(), failureReason);
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/PaymentJpaRepository.java
+++ b/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/PaymentJpaRepository.java
@@ -1,0 +1,7 @@
+package com.roovies.concertreservation.payments.infra.adapter.out.persistence;
+
+import com.roovies.concertreservation.payments.infra.adapter.out.persistence.entity.PaymentJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentJpaRepository extends JpaRepository<PaymentJpaEntity, Long> {
+}

--- a/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/PaymentRepositoryAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/PaymentRepositoryAdapter.java
@@ -1,0 +1,29 @@
+package com.roovies.concertreservation.payments.infra.adapter.out.persistence;
+
+import com.roovies.concertreservation.payments.application.port.out.PaymentRepositoryPort;
+import com.roovies.concertreservation.payments.domain.entity.Payment;
+import com.roovies.concertreservation.payments.infra.adapter.out.persistence.entity.PaymentJpaEntity;
+import com.roovies.concertreservation.shared.domain.vo.Amount;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PaymentRepositoryAdapter implements PaymentRepositoryPort {
+
+    private final PaymentJpaRepository paymentJpaRepository;
+
+    @Override
+    public Payment save(Payment payment) {
+        PaymentJpaEntity toSaveEntity = PaymentJpaEntity.from(payment);
+        PaymentJpaEntity savedEntity = paymentJpaRepository.save(toSaveEntity);
+        return Payment.restore(
+                savedEntity.getId(),
+                Amount.of(savedEntity.getOriginalAmount()),
+                Amount.of(savedEntity.getDiscountAmount()),
+                Amount.of(savedEntity.getPaidAmount()),
+                savedEntity.getStatus(),
+                savedEntity.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/entity/PaymentIdempotencyJpaEntity.java
+++ b/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/entity/PaymentIdempotencyJpaEntity.java
@@ -1,0 +1,83 @@
+package com.roovies.concertreservation.payments.infra.adapter.out.persistence.entity;
+
+import com.roovies.concertreservation.payments.domain.entity.PaymentIdempotency;
+import com.roovies.concertreservation.payments.domain.enums.PaymentIdempotencyStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "payment_idempotency",
+        indexes = {
+                @Index(name = "idx_user_created", columnList = "user_id, created_at"),
+                @Index(name = "idx_created_at", columnList = "created_at") // 스케줄러 삭제용
+        })
+public class PaymentIdempotencyJpaEntity {
+    @Id
+    @Column(name ="key", length = 255)
+    private String key;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name ="payment_id")
+    private Long paymentId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private PaymentIdempotencyStatus status;
+
+    @Column(name = "failure_reason", columnDefinition = "TEXT")
+    private String failureReason; // 실패 사유 필드 추가
+
+    @Column(name = "result_data", columnDefinition = "TEXT")
+    private String resultData;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+
+    public static PaymentIdempotencyJpaEntity from(PaymentIdempotency idempotency) {
+        return new PaymentIdempotencyJpaEntity(
+                idempotency.getKey(),
+                idempotency.getUserId(),
+                idempotency.getPaymentId(),
+                idempotency.getStatus(),
+                idempotency.getResultData(),
+                idempotency.getCreatedAt(),
+                idempotency.getCompletedAt()
+        );
+    }
+
+    private PaymentIdempotencyJpaEntity(String key, Long userId, Long paymentId,
+                                        PaymentIdempotencyStatus status, String resultData,
+                                        LocalDateTime createdAt, LocalDateTime completedAt) {
+        this.key = key;
+        this.userId = userId;
+        this.paymentId = paymentId;
+        this.status = status;
+        this.resultData = resultData;
+        this.createdAt = createdAt;
+        this.completedAt = completedAt;
+    }
+
+    public void updateResult(Long paymentId, String resultData) {
+        this.paymentId = paymentId;
+        this.resultData = resultData;
+        this.status = PaymentIdempotencyStatus.SUCCESS;
+        this.completedAt = LocalDateTime.now();
+    }
+
+    public void updateFailed(String failureReason) {
+        this.status = PaymentIdempotencyStatus.FAILED;
+        this.failureReason = failureReason;
+        this.completedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/entity/PaymentJpaEntity.java
+++ b/src/main/java/com/roovies/concertreservation/payments/infra/adapter/out/persistence/entity/PaymentJpaEntity.java
@@ -1,28 +1,34 @@
 package com.roovies.concertreservation.payments.infra.adapter.out.persistence.entity;
 
+import com.roovies.concertreservation.payments.domain.entity.Payment;
 import com.roovies.concertreservation.payments.domain.enums.PaymentStatus;
 import com.roovies.concertreservation.reservations.infra.adapter.out.persistence.entity.ReservationJpaEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @Table(name = "payments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PaymentJpaEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    // 예약 ID (FK) - 예약과 결제는 1:1
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "reservation_id", nullable = false)
-    private ReservationJpaEntity reservation;
 
-    // 결제 금액
-    @Column(name = "amount", nullable = false)
-    private Long amount;
+
+    @Column(name = "original_amount", nullable = false)
+    private Long originalAmount;
+
+    @Column(name = "discount_amount", nullable = false)
+    private Long discountAmount;
+
+    @Column(name = "paid_amount", nullable = false)
+    private Long paidAmount;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false, length = 20)
@@ -30,4 +36,24 @@ public class PaymentJpaEntity {
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public static PaymentJpaEntity from(Payment payment) {
+        return new PaymentJpaEntity(
+                payment.getId(),
+                payment.getOriginalAmount().value(),
+                payment.getDiscountAmount().value(),
+                payment.getPaidAmount().value(),
+                payment.getStatus(),
+                payment.getCreatedAt()
+        );
+    }
+
+    private PaymentJpaEntity(Long id, Long originalAmount, Long discountAmount, Long paidAmount, PaymentStatus status, LocalDateTime createdAt) {
+        this.id = id;
+        this.originalAmount = originalAmount;
+        this.discountAmount = discountAmount;
+        this.paidAmount = paidAmount;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
 }

--- a/src/main/java/com/roovies/concertreservation/points/application/port/in/GetPointUseCase.java
+++ b/src/main/java/com/roovies/concertreservation/points/application/port/in/GetPointUseCase.java
@@ -1,0 +1,5 @@
+package com.roovies.concertreservation.points.application.port.in;
+
+public interface GetPointUseCase {
+    Long execute(Long userId);
+}

--- a/src/main/java/com/roovies/concertreservation/points/application/service/GetPointService.java
+++ b/src/main/java/com/roovies/concertreservation/points/application/service/GetPointService.java
@@ -1,0 +1,24 @@
+package com.roovies.concertreservation.points.application.service;
+
+import com.roovies.concertreservation.points.application.port.in.GetPointUseCase;
+import com.roovies.concertreservation.points.application.port.out.PointRepositoryPort;
+import com.roovies.concertreservation.points.domain.entity.Point;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
+public class GetPointService implements GetPointUseCase {
+
+    private final PointRepositoryPort pointRepositoryPort;
+
+    @Override
+    public Long execute(Long userId) {
+        Point point = pointRepositoryPort.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("포인트 정보가 존재하지 않습니다."));
+
+        return point.getAmount().value();
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/reservations/application/dto/query/GetHeldSeatsQuery.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/application/dto/query/GetHeldSeatsQuery.java
@@ -1,0 +1,13 @@
+package com.roovies.concertreservation.reservations.application.dto.query;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record GetHeldSeatsQuery(
+        Long scheduleId,
+        List<Long> seatIds,
+        Long userId
+) {
+}

--- a/src/main/java/com/roovies/concertreservation/reservations/application/dto/result/HoldSeatResult.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/application/dto/result/HoldSeatResult.java
@@ -6,9 +6,10 @@ public record HoldSeatResult(
         Long scheduleId,
         List<Long> seatIds,
         Long userId,
+        Long totalPrice,
         long ttlSeconds
 ) {
-    public static HoldSeatResult of(Long scheduleId, List<Long> seatIds, Long userId, long ttlSeconds) {
-        return new HoldSeatResult(scheduleId, seatIds, userId, ttlSeconds);
+    public static HoldSeatResult of(Long scheduleId, List<Long> seatIds, Long userId, Long totalPrice, long ttlSeconds) {
+        return new HoldSeatResult(scheduleId, seatIds, userId, totalPrice, ttlSeconds);
     }
 }

--- a/src/main/java/com/roovies/concertreservation/reservations/application/port/in/GetHeldSeatsUseCase.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/application/port/in/GetHeldSeatsUseCase.java
@@ -1,0 +1,8 @@
+package com.roovies.concertreservation.reservations.application.port.in;
+
+import com.roovies.concertreservation.reservations.application.dto.query.GetHeldSeatsQuery;
+import com.roovies.concertreservation.reservations.application.dto.result.HoldSeatResult;
+
+public interface GetHeldSeatsUseCase {
+    HoldSeatResult execute(GetHeldSeatsQuery query);
+}

--- a/src/main/java/com/roovies/concertreservation/reservations/application/port/out/HoldSeatCachePort.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/application/port/out/HoldSeatCachePort.java
@@ -1,5 +1,7 @@
 package com.roovies.concertreservation.reservations.application.port.out;
 
+import com.roovies.concertreservation.reservations.domain.entity.HoldSeat;
+
 import java.util.List;
 
 public interface HoldSeatCachePort {
@@ -7,4 +9,5 @@ public interface HoldSeatCachePort {
     boolean deleteHoldSeatList(Long scheduleId, List<Long> seatIds, Long userId);
     boolean validateHoldSeatList(Long scheduleId, List<Long> seatIds, Long userId);
     long getHoldTTLSeconds(Long scheduleId, List<Long> seatIds, Long userId);
+    List<HoldSeat> getHoldSeatList(Long scheduleId, List<Long> seatIds, Long userId);
 }

--- a/src/main/java/com/roovies/concertreservation/reservations/application/port/out/ReservationVenueQueryPort.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/application/port/out/ReservationVenueQueryPort.java
@@ -2,6 +2,9 @@ package com.roovies.concertreservation.reservations.application.port.out;
 
 import com.roovies.concertreservation.reservations.domain.vo.external.ReservationVenueSnapShot;
 
+import java.util.List;
+
 public interface ReservationVenueQueryPort {
     ReservationVenueSnapShot findVenueWithSeats(Long venueId);
+    Long getTotalSeatPrice(List<Long> seatIds);
 }

--- a/src/main/java/com/roovies/concertreservation/reservations/application/service/GetHeldSeatsService.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/application/service/GetHeldSeatsService.java
@@ -1,0 +1,39 @@
+package com.roovies.concertreservation.reservations.application.service;
+
+import com.roovies.concertreservation.reservations.application.dto.query.GetHeldSeatsQuery;
+import com.roovies.concertreservation.reservations.application.dto.result.HoldSeatResult;
+import com.roovies.concertreservation.reservations.application.port.in.GetHeldSeatsUseCase;
+import com.roovies.concertreservation.reservations.application.port.out.HoldSeatCachePort;
+import com.roovies.concertreservation.reservations.application.port.out.ReservationVenueQueryPort;
+import com.roovies.concertreservation.reservations.domain.entity.HoldSeat;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetHeldSeatsService implements GetHeldSeatsUseCase {
+
+    private final HoldSeatCachePort holdSeatCachePort;
+    private final ReservationVenueQueryPort reservationVenueQueryPort;
+
+    @Override
+    public HoldSeatResult execute(GetHeldSeatsQuery query) {
+        List<HoldSeat> response = holdSeatCachePort.getHoldSeatList(query.scheduleId(), query.seatIds(), query.userId());
+        if (response.isEmpty())
+            return HoldSeatResult.of(query.scheduleId(), Collections.emptyList(), query.userId(), 0L, 0L);
+
+        long ttl = holdSeatCachePort.getHoldTTLSeconds(query.scheduleId(), query.seatIds(), query.userId());
+        List<Long> seatIds = response.stream()
+                .map(holdSeat -> holdSeat.getSeatId())
+                .toList();
+        Long scheduleId = response.get(0).getScheduleId();
+        Long totalPrice = reservationVenueQueryPort.getTotalSeatPrice(seatIds);
+
+        return HoldSeatResult.of(scheduleId, seatIds, query.userId(), totalPrice, ttl);
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/reservations/application/service/HoldSeatService.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/application/service/HoldSeatService.java
@@ -61,7 +61,7 @@ public class HoldSeatService implements HoldSeatUseCase {
             // 5. 만약 현재 사용자가 모든 좌석을 홀딩하고 있다면 이미 예약하고 있으므로 결과 반환
             if (holdSeatCachePort.validateHoldSeatList(scheduleId, uniqueSeatIds, userId)) {
                 long ttl = holdSeatCachePort.getHoldTTLSeconds(scheduleId, uniqueSeatIds, userId);
-                return HoldSeatResult.of(scheduleId, uniqueSeatIds, userId, ttl);
+                return HoldSeatResult.of(scheduleId, uniqueSeatIds, userId,0L, ttl); // TODO: totalPrice 계산 후 적재해줘야 함
             }
 
             // 6. 좌석 예약 시도
@@ -74,6 +74,7 @@ public class HoldSeatService implements HoldSeatUseCase {
                     scheduleId,
                     uniqueSeatIds,
                     userId,
+                    0L, // TODO: totalPrice 계산 후 적재해줘야 함
                     holdSeatCachePort.getHoldTTLSeconds(scheduleId, uniqueSeatIds, userId)
             );
 

--- a/src/main/java/com/roovies/concertreservation/reservations/domain/entity/HoldSeat.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/domain/entity/HoldSeat.java
@@ -1,0 +1,38 @@
+package com.roovies.concertreservation.reservations.domain.entity;
+
+import lombok.Getter;
+
+@Getter
+public class HoldSeat {
+    private final Long scheduleId;
+    private final Long seatId;
+    private final Long holdUserId;
+    private final long remainSeconds;
+
+    public static HoldSeat create(Long scheduleId, Long seatId, Long holdUserId,
+                                  long remainSeconds) {
+        return new HoldSeat(scheduleId, seatId, holdUserId, remainSeconds);
+    }
+
+    private HoldSeat(Long scheduleId, Long seatId, Long holdUserId,
+                     long remainSeconds) {
+        this.scheduleId = scheduleId;
+        this.seatId = seatId;
+        this.holdUserId = holdUserId;
+        this.remainSeconds = remainSeconds;
+    }
+
+    /**
+     * 홀딩이 만료되었는지 확인
+     */
+    public boolean isExpired() {
+        return remainSeconds <= 0;
+    }
+
+    /**
+     * 홀딩이 곧 만료되는지 확인 (1분 이내)
+     */
+    public boolean isExpiringSoon() {
+        return remainSeconds > 0 && remainSeconds <= 60;
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/reservations/domain/entity/Reservation.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/domain/entity/Reservation.java
@@ -15,6 +15,7 @@ public class Reservation {
     // 기본 정보
     private final Long id;
     private final Long userId;
+    private final Long paymentId;
     private ReservationStatus status;
     private final LocalDateTime createdAt;
     private LocalDateTime updatedAt;
@@ -22,13 +23,14 @@ public class Reservation {
     // Child Entity
     private final List<ReservationDetail> details;
 
-    public static Reservation create(Long id, Long userId, ReservationStatus status, LocalDateTime createdAt, LocalDateTime updatedAt, List<ReservationDetail> details) {
-        return new Reservation(id, userId, status, createdAt, updatedAt, details);
+    public static Reservation create(Long id, Long userId, Long paymentId, ReservationStatus status, LocalDateTime createdAt, LocalDateTime updatedAt, List<ReservationDetail> details) {
+        return new Reservation(id, userId, paymentId, status, createdAt, updatedAt, details);
     }
 
-    private Reservation(Long id, Long userId, ReservationStatus status, LocalDateTime createdAt, LocalDateTime updatedAt, List<ReservationDetail> details) {
+    private Reservation(Long id, Long userId, Long paymentId, ReservationStatus status, LocalDateTime createdAt, LocalDateTime updatedAt, List<ReservationDetail> details) {
         this.id = id;
         this.userId = userId;
+        this.paymentId = paymentId;
         this.status = status;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;

--- a/src/main/java/com/roovies/concertreservation/reservations/infra/adapter/out/cache/HoldSeatCacheAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/infra/adapter/out/cache/HoldSeatCacheAdapter.java
@@ -1,6 +1,7 @@
 package com.roovies.concertreservation.reservations.infra.adapter.out.cache;
 
 import com.roovies.concertreservation.reservations.application.port.out.HoldSeatCachePort;
+import com.roovies.concertreservation.reservations.domain.entity.HoldSeat;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RBucket;
@@ -10,7 +11,9 @@ import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.concurrent.TimeUnit;
 
 @Repository
@@ -235,7 +238,6 @@ public class HoldSeatCacheAdapter implements HoldSeatCachePort {
         }
     }
 
-
     /**
      * 주어진 좌석 목록의 TTL(만료까지 남은 시간)을 조회.
      * 모든 좌석이 동일 TTL로 설정된다고 가정하고, 첫 번째 좌석 기준으로 TTL 반환.
@@ -274,6 +276,66 @@ public class HoldSeatCacheAdapter implements HoldSeatCachePort {
                     scheduleId, seatIds, userId, e);
         }
         return -2;
+    }
+
+    /**
+     * 주어진 좌석 목록의 홀딩 상태를 조회하여 Domain 객체로 반환.
+     *
+     * @param scheduleId 조회할 스케줄 ID
+     * @param seatIds 조회할 좌석 ID 목록
+     * @param userId 요청한 사용자 ID (권한 검증용)
+     * @return 홀딩된 좌석 정보 목록 (Domain 객체)
+     */
+    @Override
+    public List<HoldSeat> getHoldSeatList(Long scheduleId, List<Long> seatIds, Long userId) {
+        try {
+            List<HoldSeat> results = new ArrayList<>();
+
+            for (Long seatId : seatIds) {
+                String holdKey = createHoldKey(scheduleId, seatId);
+                RBucket<String> bucket = redissonClient.getBucket(holdKey);
+
+                if (!bucket.isExists()) {
+                    // 홀딩되지 않은 좌석이 있으면 예외 발생
+                    return Collections.emptyList();
+                }
+
+                String holdUserIdStr = bucket.get();
+                if (holdUserIdStr == null) {
+                    log.warn("홀딩 키는 존재하지만 값이 null: scheduleId={}, seatId={}", scheduleId, seatId);
+                    return Collections.emptyList();
+                }
+
+                // TTL 조회 (남은 시간)
+                long remainMillis = bucket.remainTimeToLive();
+                long remainSeconds = remainMillis > 0 ? TimeUnit.MILLISECONDS.toSeconds(remainMillis) : -1;
+
+                Long holdUserId = Long.valueOf(holdUserIdStr);
+                // 현재 사용자가 홀딩한 좌석이 아니면 예외 발생
+                if (!holdUserId.equals(userId)) {
+                    return Collections.emptyList();
+                }
+
+                // Domain 객체 생성하여 추가
+                HoldSeat holdSeat = HoldSeat.create(
+                        scheduleId,
+                        seatId,
+                        holdUserId,
+                        remainSeconds
+                );
+                results.add(holdSeat);
+            }
+
+            log.debug("홀딩된 좌석 조회 완료: scheduleId={}, 요청좌석수={}, 홀딩좌석수={}, userId={}",
+                    scheduleId, seatIds.size(), results.size(), userId);
+
+            return results;
+
+        } catch (Exception e) {
+            log.error("홀딩된 좌석 조회 중 예외 발생: scheduleId={}, seatIds={}, userId={}",
+                    scheduleId, seatIds, userId, e);
+            return Collections.emptyList();
+        }
     }
 
     private String createLockKey(Long scheduleId, Long seatId) {

--- a/src/main/java/com/roovies/concertreservation/reservations/infra/adapter/out/persistence/ReservationRepositoryAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/infra/adapter/out/persistence/ReservationRepositoryAdapter.java
@@ -28,6 +28,7 @@ public class ReservationRepositoryAdapter implements ReservationRepositoryPort {
                     Reservation.create(
                             reservation.getId(),
                             reservation.getUser().getId(),
+                            reservation.getPaymentJpaEntity().getId(),
                             reservation.getStatus(),
                             reservation.getCreatedAt(),
                             reservation.getUpdatedAt(),
@@ -60,6 +61,7 @@ public class ReservationRepositoryAdapter implements ReservationRepositoryPort {
                     return Reservation.create(
                             entity.getId(),
                             entity.getUser().getId(),
+                            entity.getPaymentJpaEntity().getId(),
                             entity.getStatus(),
                             entity.getCreatedAt(),
                             entity.getUpdatedAt(),

--- a/src/main/java/com/roovies/concertreservation/reservations/infra/adapter/out/persistence/entity/ReservationJpaEntity.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/infra/adapter/out/persistence/entity/ReservationJpaEntity.java
@@ -1,5 +1,6 @@
 package com.roovies.concertreservation.reservations.infra.adapter.out.persistence.entity;
 
+import com.roovies.concertreservation.payments.infra.adapter.out.persistence.entity.PaymentJpaEntity;
 import com.roovies.concertreservation.reservations.domain.enums.ReservationStatus;
 import com.roovies.concertreservation.users.infra.adapter.out.persistence.entity.UserJpaEntity;
 import jakarta.persistence.*;
@@ -19,6 +20,11 @@ public class ReservationJpaEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // 결제 ID (FK) - 예약과 결제는 1:1
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id", nullable = false)
+    private PaymentJpaEntity paymentJpaEntity;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id", nullable = false)

--- a/src/main/java/com/roovies/concertreservation/reservations/infra/adapter/out/venue/ReservationVenueQueryAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/reservations/infra/adapter/out/venue/ReservationVenueQueryAdapter.java
@@ -1,6 +1,7 @@
 package com.roovies.concertreservation.reservations.infra.adapter.out.venue;
 
 import com.roovies.concertreservation.venues.application.dto.result.GetVenueWithSeatsResult;
+import com.roovies.concertreservation.venues.application.port.in.GetSeatsTotalPriceUseCase;
 import com.roovies.concertreservation.venues.application.port.in.GetVenueWithSeatsUseCase;
 import com.roovies.concertreservation.reservations.application.port.out.ReservationVenueQueryPort;
 import com.roovies.concertreservation.reservations.domain.vo.external.ReservationVenueSnapShot;
@@ -14,6 +15,7 @@ import java.util.List;
 public class ReservationVenueQueryAdapter implements ReservationVenueQueryPort {
 
     private final GetVenueWithSeatsUseCase getVenueWithSeatsUseCase;
+    private final GetSeatsTotalPriceUseCase getSeatsTotalPriceUseCase;
 
     @Override
     public ReservationVenueSnapShot findVenueWithSeats(Long venueId) {
@@ -35,5 +37,10 @@ public class ReservationVenueQueryAdapter implements ReservationVenueQueryPort {
                 .totalSeats(result.totalSeats())
                 .seats(seats)
                 .build();
+    }
+
+    @Override
+    public Long getTotalSeatPrice(List<Long> seatIds) {
+        return getSeatsTotalPriceUseCase.execute(seatIds);
     }
 }

--- a/src/main/java/com/roovies/concertreservation/users/application/dto/response/GetUserByIdResult.java
+++ b/src/main/java/com/roovies/concertreservation/users/application/dto/response/GetUserByIdResult.java
@@ -1,4 +1,0 @@
-package com.roovies.concertreservation.users.application.dto.response;
-
-public record GetUserByIdResult() {
-}

--- a/src/main/java/com/roovies/concertreservation/users/application/dto/result/GetUserByIdResult.java
+++ b/src/main/java/com/roovies/concertreservation/users/application/dto/result/GetUserByIdResult.java
@@ -1,0 +1,18 @@
+package com.roovies.concertreservation.users.application.dto.result;
+
+import com.roovies.concertreservation.users.domain.enums.UserStatus;
+
+import java.time.LocalDateTime;
+
+public record GetUserByIdResult(
+        Long id,
+        String email,
+        String name,
+        String nickname,
+        UserStatus status,
+        LocalDateTime createdAt
+) {
+    public static GetUserByIdResult of(Long id, String email, String name, String nickname, UserStatus status, LocalDateTime createdAt) {
+        return new GetUserByIdResult(id, email, name, nickname, status, createdAt);
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/users/application/port/in/GetUserByIdUseCase.java
+++ b/src/main/java/com/roovies/concertreservation/users/application/port/in/GetUserByIdUseCase.java
@@ -1,4 +1,7 @@
 package com.roovies.concertreservation.users.application.port.in;
 
+import com.roovies.concertreservation.users.application.dto.result.GetUserByIdResult;
+
 public interface GetUserByIdUseCase {
+    GetUserByIdResult findById(Long id);
 }

--- a/src/main/java/com/roovies/concertreservation/users/application/port/in/UpdateUserPointUseCase.java
+++ b/src/main/java/com/roovies/concertreservation/users/application/port/in/UpdateUserPointUseCase.java
@@ -1,0 +1,5 @@
+package com.roovies.concertreservation.users.application.port.in;
+
+public interface UpdateUserPointUseCase {
+    void updatePoint(Long id, int point);
+}

--- a/src/main/java/com/roovies/concertreservation/users/application/port/out/UserRepositoryPort.java
+++ b/src/main/java/com/roovies/concertreservation/users/application/port/out/UserRepositoryPort.java
@@ -1,4 +1,9 @@
 package com.roovies.concertreservation.users.application.port.out;
 
+import com.roovies.concertreservation.users.domain.entity.User;
+
+import java.util.Optional;
+
 public interface UserRepositoryPort {
+    Optional<User> findById(Long id);
 }

--- a/src/main/java/com/roovies/concertreservation/users/application/service/GetUserByIdService.java
+++ b/src/main/java/com/roovies/concertreservation/users/application/service/GetUserByIdService.java
@@ -1,6 +1,25 @@
 package com.roovies.concertreservation.users.application.service;
 
+import com.roovies.concertreservation.users.application.dto.result.GetUserByIdResult;
 import com.roovies.concertreservation.users.application.port.in.GetUserByIdUseCase;
+import com.roovies.concertreservation.users.application.port.out.UserRepositoryPort;
+import com.roovies.concertreservation.users.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+import java.util.NoSuchElementException;
+
+@Service
+@RequiredArgsConstructor
 public class GetUserByIdService implements GetUserByIdUseCase {
+
+    private final UserRepositoryPort userRepositoryPort;
+
+    @Override
+    public GetUserByIdResult findById(Long id) {
+        User user = userRepositoryPort.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));
+
+        return null;
+    }
 }

--- a/src/main/java/com/roovies/concertreservation/users/application/service/UpdateUserPointService.java
+++ b/src/main/java/com/roovies/concertreservation/users/application/service/UpdateUserPointService.java
@@ -1,0 +1,10 @@
+package com.roovies.concertreservation.users.application.service;
+
+import com.roovies.concertreservation.users.application.port.in.UpdateUserPointUseCase;
+
+public class UpdateUserPointService implements UpdateUserPointUseCase {
+    @Override
+    public void updatePoint(Long id, int point) {
+        
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/users/domain/entity/User.java
+++ b/src/main/java/com/roovies/concertreservation/users/domain/entity/User.java
@@ -5,18 +5,36 @@ import com.roovies.concertreservation.users.domain.vo.Email;
 import com.roovies.concertreservation.users.domain.vo.Name;
 import com.roovies.concertreservation.users.domain.vo.Nickname;
 import com.roovies.concertreservation.users.domain.vo.Password;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 public class User {
+    // TODO: 의미있는 값은 VO 처리 해야 함
     private Long id;
-    private Email email;
-    private Password password;
-    private Name name;
-    private Nickname nickname;
+    private String email;
+    private String password;
+    private String name;
+    private String nickname;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
     private LocalDateTime deletedAt;
     private UserStatus status;
     // 이하 생략
+
+    public static User create(Long id, String email, String name, String nickname, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, UserStatus status) {
+        return new User(id, email, name, nickname, createdAt, updatedAt, deletedAt, status);
+    }
+
+    private User(Long id, String email, String name, String nickname, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt, UserStatus status) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+        this.nickname = nickname;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.deletedAt = deletedAt;
+        this.status = status;
+    }
 }

--- a/src/main/java/com/roovies/concertreservation/users/domain/vo/Email.java
+++ b/src/main/java/com/roovies/concertreservation/users/domain/vo/Email.java
@@ -1,4 +1,9 @@
 package com.roovies.concertreservation.users.domain.vo;
 
-public record Email() {
+public record Email(
+        String value
+) {
+    public static Email of(String value) {
+        return new Email(value);
+    }
 }

--- a/src/main/java/com/roovies/concertreservation/users/infra/adapter/out/persistence/UserRepositoryAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/users/infra/adapter/out/persistence/UserRepositoryAdapter.java
@@ -1,9 +1,37 @@
 package com.roovies.concertreservation.users.infra.adapter.out.persistence;
 
 import com.roovies.concertreservation.users.application.port.out.UserRepositoryPort;
+import com.roovies.concertreservation.users.domain.entity.User;
+import com.roovies.concertreservation.users.domain.vo.Email;
+import com.roovies.concertreservation.users.infra.adapter.out.persistence.entity.UserJpaEntity;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 @RequiredArgsConstructor
 public class UserRepositoryAdapter implements UserRepositoryPort {
     private final UserJpaRepository userJpaRepository;
+
+    @Override
+    public Optional<User> findById(Long id) {
+        Optional<UserJpaEntity> entity = userJpaRepository.findById(id);
+        if (entity.isPresent()) {
+            UserJpaEntity userEntity = entity.get();
+            return Optional.of(
+                    User.create(
+                        userEntity.getId(),
+                        userEntity.getEmail(),
+                        userEntity.getName(),
+                        userEntity.getNickname(),
+                        userEntity.getCreatedAt(),
+                        userEntity.getUpdatedAt(),
+                        userEntity.getDeletedAt(),
+                        userEntity.getStatus()
+                    )
+            );
+        }
+        return Optional.empty();
+    }
 }

--- a/src/main/java/com/roovies/concertreservation/venues/application/port/in/GetSeatsTotalPriceUseCase.java
+++ b/src/main/java/com/roovies/concertreservation/venues/application/port/in/GetSeatsTotalPriceUseCase.java
@@ -1,0 +1,7 @@
+package com.roovies.concertreservation.venues.application.port.in;
+
+import java.util.List;
+
+public interface GetSeatsTotalPriceUseCase {
+    Long execute(List<Long> seatIds);
+}

--- a/src/main/java/com/roovies/concertreservation/venues/application/port/out/VenueRepositoryPort.java
+++ b/src/main/java/com/roovies/concertreservation/venues/application/port/out/VenueRepositoryPort.java
@@ -2,9 +2,11 @@ package com.roovies.concertreservation.venues.application.port.out;
 
 import com.roovies.concertreservation.venues.domain.entity.Venue;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface VenueRepositoryPort {
     Optional<Venue> findById(Long venueId);
     Optional<Venue> findByIdWithSeats(Long venueId);
+    Long getTotalSeatsPrice(List<Long> seatIds);
 }

--- a/src/main/java/com/roovies/concertreservation/venues/application/service/GetSeatsTotalPriceService.java
+++ b/src/main/java/com/roovies/concertreservation/venues/application/service/GetSeatsTotalPriceService.java
@@ -1,0 +1,26 @@
+package com.roovies.concertreservation.venues.application.service;
+
+import com.roovies.concertreservation.venues.application.port.in.GetSeatsTotalPriceUseCase;
+import com.roovies.concertreservation.venues.application.port.out.VenueRepositoryPort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GetSeatsTotalPriceService implements GetSeatsTotalPriceUseCase {
+
+    private final VenueRepositoryPort venueRepositoryPort;
+
+    @Override
+    public Long execute(List<Long> seatIds) {
+        if (seatIds == null || seatIds.isEmpty()) {
+            return 0L;
+        }
+
+        return venueRepositoryPort.getTotalSeatsPrice(seatIds);
+    }
+}

--- a/src/main/java/com/roovies/concertreservation/venues/infra/adapter/out/persistence/VenueRepositoryAdapter.java
+++ b/src/main/java/com/roovies/concertreservation/venues/infra/adapter/out/persistence/VenueRepositoryAdapter.java
@@ -65,4 +65,13 @@ public class VenueRepositoryAdapter implements VenueRepositoryPort {
         }
         return Optional.empty();
     }
+
+    @Override
+    public Long getTotalSeatsPrice(List<Long> seatIds) {
+        if (seatIds == null || seatIds.isEmpty()) {
+            return 0L;
+        }
+
+        return venueSeatJpaRepository.getTotalPriceBySeatIds(seatIds);
+    }
 }

--- a/src/main/java/com/roovies/concertreservation/venues/infra/adapter/out/persistence/VenueSeatJpaRepository.java
+++ b/src/main/java/com/roovies/concertreservation/venues/infra/adapter/out/persistence/VenueSeatJpaRepository.java
@@ -2,9 +2,13 @@ package com.roovies.concertreservation.venues.infra.adapter.out.persistence;
 
 import com.roovies.concertreservation.venues.infra.adapter.out.persistence.entity.VenueSeatJpaEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface VenueSeatJpaRepository extends JpaRepository<VenueSeatJpaEntity, Long> {
     List<VenueSeatJpaEntity> findByVenueId(Long venueId);
+
+    @Query("SELECT COALESCE(SUM(vs.price), 0) FROM VenueSeatJpaEntity vs WHERE vs.id IN :seatIds")
+    Long getTotalPriceBySeatIds(List<Long> seatIds);
 }

--- a/src/test/java/com/roovies/concertreservation/payments/domain/PaymentIdempotencyTest.java
+++ b/src/test/java/com/roovies/concertreservation/payments/domain/PaymentIdempotencyTest.java
@@ -1,0 +1,95 @@
+package com.roovies.concertreservation.payments.domain;
+
+import com.roovies.concertreservation.payments.domain.entity.PaymentIdempotency;
+import com.roovies.concertreservation.payments.domain.enums.PaymentIdempotencyStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+public class PaymentIdempotencyTest {
+
+    @Test
+    void 결제_멱등성_정보_생성시_PROCESSING_상태여야_한다() {
+        // given
+        String idempotencyKey = "payment_key_12345";
+        Long userId = 1L;
+        Long paymentId = 12345L;
+        PaymentIdempotencyStatus status = PaymentIdempotencyStatus.PROCESSING;
+        String resultData = "test";
+        LocalDateTime createdAt = LocalDateTime.of(2025, 9, 18, 14, 30, 25);
+        LocalDateTime completedAt = LocalDateTime.of(2025, 9, 18, 14, 30, 25);
+
+        // when
+        PaymentIdempotency paymentIdempotency = PaymentIdempotency.create(idempotencyKey, userId, paymentId, status, resultData, createdAt, completedAt);
+
+        // then
+        assertThat(paymentIdempotency)
+                .extracting("key", "userId", "status")
+                .containsExactly(idempotencyKey, userId, PaymentIdempotencyStatus.PROCESSING);
+
+        assertThat(paymentIdempotency.isProcessing()).isTrue();
+    }
+
+    @Test
+    void 결제_멱등성_정보_생성시_결제ID와_응답데이터는_null이어야_한다() {
+        // given
+        String idempotencyKey = "payment_key_12345";
+        Long userId = 1L;
+        Long paymentId = null;
+        PaymentIdempotencyStatus status = PaymentIdempotencyStatus.PROCESSING;
+        String resultData = null;
+        LocalDateTime createdAt = LocalDateTime.of(2025, 9, 18, 14, 30, 25);
+        LocalDateTime completedAt = LocalDateTime.of(2025, 9, 18, 14, 30, 25);
+
+        // when
+        PaymentIdempotency paymentIdempotency = PaymentIdempotency.create(idempotencyKey, userId, paymentId, status, resultData, createdAt, completedAt);
+
+        // then
+        assertThat(paymentIdempotency.getPaymentId()).isNull();
+        assertThat(paymentIdempotency.getResultData()).isNull();
+    }
+
+    @Test
+    void 결제_멱등성_정보에_응답용_데이터를_적재하면_SUCCESS_상태여야_한다() {
+        // given
+        String idempotencyKey = "payment_key_12345";
+        Long userId = 1L;
+        Long paymentId = 12345L;
+        PaymentIdempotencyStatus status = PaymentIdempotencyStatus.PROCESSING;
+        String resultData = "test";
+        LocalDateTime createdAt = LocalDateTime.of(2025, 9, 18, 14, 30, 25);
+        LocalDateTime completedAt = LocalDateTime.of(2025, 9, 18, 14, 30, 25);
+        // when
+        PaymentIdempotency paymentIdempotency = PaymentIdempotency.create(idempotencyKey, userId, paymentId, status, resultData, createdAt, completedAt);
+        paymentIdempotency.setResult(paymentId, resultData);
+
+        // then
+        assertThat(paymentIdempotency.getResultData()).isNotNull();
+        assertThat(paymentIdempotency.getStatus()).isEqualTo(PaymentIdempotencyStatus.SUCCESS);
+        assertThat(paymentIdempotency.getCompletedAt()).isNotNull();
+    }
+
+    @Test
+    void 결제_멱등성_정보가_SUCCESS일_경우_결제ID가_매핑되어야_한다() {
+        // given
+        String idempotencyKey = "payment_key_12345";
+        Long userId = 1L;
+        Long paymentId = 12345L;
+        PaymentIdempotencyStatus status = PaymentIdempotencyStatus.PROCESSING;
+        String resultData = "test";
+        LocalDateTime createdAt = LocalDateTime.of(2025, 9, 18, 14, 30, 25);
+        LocalDateTime completedAt = LocalDateTime.of(2025, 9, 18, 14, 30, 25);
+
+        // when
+        PaymentIdempotency paymentIdempotency = PaymentIdempotency.create(idempotencyKey, userId, paymentId, status, resultData, createdAt, completedAt);
+        paymentIdempotency.setResult(paymentId, resultData);
+
+        // then
+        assertThat(paymentIdempotency.getStatus()).isEqualTo(PaymentIdempotencyStatus.SUCCESS);
+        assertThat(paymentIdempotency.getPaymentId()).isNotNull();
+    }
+}

--- a/src/test/java/com/roovies/concertreservation/payments/domain/PaymentTest.java
+++ b/src/test/java/com/roovies/concertreservation/payments/domain/PaymentTest.java
@@ -1,0 +1,115 @@
+package com.roovies.concertreservation.payments.domain;
+
+
+import com.roovies.concertreservation.payments.domain.entity.Payment;
+import com.roovies.concertreservation.shared.domain.vo.Amount;
+import org.junit.jupiter.api.Test;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+public class PaymentTest {
+    @Test
+    void 결제_금액은_null일_수_없다() {
+        // given
+        Long paymentId = 1L;
+        Amount originalAmount = Amount.of(1000L);
+        Amount paidAmount = null;
+
+        // when & then
+        assertThatThrownBy(() -> Payment.create(paymentId, originalAmount, paidAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("결제 금액은 null일 수 없습니다.");
+    }
+
+    @Test
+    void 결제_금액은_0원일_수_없다() {
+        // given
+        Long paymentId = 1L;
+        Amount originalAmount = Amount.of(1000L);
+        Amount paidAmount = Amount.of(0L);
+
+        // when & then
+        assertThatThrownBy(() -> Payment.create(
+                paymentId,
+                originalAmount,
+                paidAmount
+        )).isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("결제 금액은 0원일 수 없습니다.");
+    }
+
+    @Test
+    void 결제_금액은_100원_단위어야_한다() {
+        // given
+        Long paymentId = 1L;
+        Long reservationId = 5L;
+        Amount originalAmount = Amount.of(1000L);
+        Amount paidAmount = Amount.of(110L);
+
+        // when & then
+        assertThatThrownBy(() -> Payment.create(paymentId, originalAmount, paidAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("결제 금액은 100원 단위어야 합니다.");
+    }
+
+    @Test
+    void 결제_금액은_정가보다_많을_수_없다() {
+        // given
+        Long paymentId = 1L;
+        Amount originalAmount = Amount.of(1000L);
+        Amount paidAmount = Amount.of(1100L);
+
+        // when & then
+        assertThatThrownBy(() -> Payment.create(paymentId, originalAmount, paidAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("결제 금액이 정가보다 많습니다.");
+    }
+
+    @Test
+    void 정가는_100원_단위로_책정되어야_한다() {
+        // given
+        Long paymentId = 1L;
+        Amount originalAmount = Amount.of(110L);
+        Amount paidAmount = Amount.of(1100L);
+
+        // when & then
+        assertThatThrownBy(() -> Payment.create(paymentId, originalAmount, paidAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("정가는 100원 단위어야 합니다.");
+    }
+
+    @Test
+    void discount_메서드를_통해_할인을_적용하면_결제_금액이_할인된_금액만큼_차감되어야_한다() {
+        // given
+        Long paymentId = 1L;
+        Amount originalAmount = Amount.of(1000L);
+        Amount paidAmount = Amount.of(1000L);
+
+        Amount discoundAmount = Amount.of(500L);
+        Long expectedPaidAmount = 500L;
+
+        // when
+        Payment payment = Payment.create(paymentId, originalAmount, paidAmount);
+        payment.discount(discoundAmount);
+
+        // then
+        assertThat(payment.getDiscountAmount().value()).isEqualTo(discoundAmount.value());
+        assertThat(payment.getPaidAmount().value()).isEqualTo(expectedPaidAmount);
+    }
+
+    @Test
+    void 정가는_null일_수_없다() {
+        // given
+        Long paymentId = 1L;
+        Amount originalAmount = null;
+        Amount paidAmount = Amount.of(1000L);
+
+        // when & then
+        assertThatThrownBy(() -> Payment.create(paymentId, originalAmount, paidAmount))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("정가는 null일 수 없습니다.");
+    }
+
+}

--- a/src/test/java/com/roovies/concertreservation/reservations/application/GetAvailableSeatsUseCaseTest.java
+++ b/src/test/java/com/roovies/concertreservation/reservations/application/GetAvailableSeatsUseCaseTest.java
@@ -235,7 +235,7 @@ public class GetAvailableSeatsUseCaseTest {
                 ReservationDetail.create(1L, 100L, 5L, 1L)
         );
         List<Reservation> reservations = List.of(
-                Reservation.create(100L, 1000L, ReservationStatus.CONFIRMED,
+                Reservation.create(100L, 1000L, 5L, ReservationStatus.CONFIRMED,
                         LocalDateTime.now(), LocalDateTime.now(), reservationDetails)
         );
         given(reservationRepositoryPort.findReservationsByDetailScheduleId(schedule.id()))

--- a/src/test/java/com/roovies/concertreservation/reservations/application/HoldSeatUseCaseTest.java
+++ b/src/test/java/com/roovies/concertreservation/reservations/application/HoldSeatUseCaseTest.java
@@ -265,7 +265,7 @@ HoldSeatUseCaseTest {
     void 이미_멱등성키가_존재할_경우_캐싱된_결과를_반환해야_한다() {
         // given
         List<Long> seatIds = Arrays.asList(101L, 102L, 103L, 102L, 101L);
-        HoldSeatResult cached = HoldSeatResult.of(1L, seatIds, 5L, 500);
+        HoldSeatResult cached = HoldSeatResult.of(1L, seatIds, 5L, 5L, 500);
         given(holdSeatIdempotencyCachePort.findByIdempotencyKey(command.idempotencyKey()))
                 .willReturn(cached);
 

--- a/src/test/java/com/roovies/concertreservation/reservations/domain/ReservationTest.java
+++ b/src/test/java/com/roovies/concertreservation/reservations/domain/ReservationTest.java
@@ -22,6 +22,7 @@ public class ReservationTest {
         assertThatThrownBy(() -> Reservation.create(
                 1L,
                 5L,
+                5L,
                 ReservationStatus.HOLD,
                 LocalDateTime.of(2025, 9, 9, 15, 26),
                 null,
@@ -39,6 +40,7 @@ public class ReservationTest {
         // when & then
         assertThatThrownBy(() -> Reservation.create(
                 1L,
+                5L,
                 5L,
                 ReservationStatus.HOLD,
                 LocalDateTime.of(2025, 9, 9, 15, 26),
@@ -63,6 +65,7 @@ public class ReservationTest {
         // when
         Reservation reservation = Reservation.create(
                 1L,
+                5L,
                 5L,
                 ReservationStatus.HOLD,
                 LocalDateTime.of(2025, 9, 9, 15, 26),
@@ -99,6 +102,7 @@ public class ReservationTest {
         assertThatThrownBy(() -> Reservation.create(
                 10L,
                 5L,
+                5L,
                 ReservationStatus.HOLD,
                 LocalDateTime.of(2025, 9, 9, 15, 26),
                 null,
@@ -122,6 +126,7 @@ public class ReservationTest {
         Reservation reservation = Reservation.create(
                 5L,
                 1L,
+                5L,
                 ReservationStatus.HOLD,
                 LocalDateTime.of(2025, 9, 9, 15, 26),
                 null,
@@ -163,6 +168,7 @@ public class ReservationTest {
         assertThatThrownBy(() -> Reservation.create(
                 5L,
                 1L,
+                5L,
                 ReservationStatus.HOLD,
                 LocalDateTime.of(2025, 9, 9, 15, 26),
                 null,


### PR DESCRIPTION
<!--
  제목은 [(과제 STEP)] (작업한 내용) 로 작성해 주세요
  예시: [STEP-5] 이커머스 시스템 설계 
-->

## PR 설명
- 콘서트 상세 정보 조회: 4c1d80424e2a30d19fed54f2cd5703086a99e091
- 일정별 예약 가능 좌석 조회: 5dffbe9054da9fd77dc5ebf551e3512199572e41
- 좌석 예약(결제X. 홀딩만): 5d2fd51c29b5d1236fba19fe59843b9fb0201a36
- 좌석 예약 멱등성 처리: 22208791ba106f9b47620e8e02bebfdfcfdc1c28
- 포인트 충전: 0b755025925a033e792bae3d7b9615f4ad494ee5
- 결제: (현재) PR f1f11c066fd9af4e83e061715ceb7b693279da6d
    - Reservation 및 Reservation Detail 추가 기능 미구현 상태 (뒤늦게 인지)

## 리뷰 포인트
1. 전반적으로 헥사고날 아키텍처가 구조에 맞게 잘 설계되었는지
2. 책임 분리와 계층간의 통신이 구조에 맞게 잘 구성되어 있는지
3. 비즈니스 로직 코드 구현이 적절히 되었는지
- 대표적인 예시로 이번에 설계를 잘못해서 결제 기능에서 추가적으로 예약한 좌석의 총액을 재조회하는 불상사가 발생했는데, 해당 로직을 좌석 예약이 성공할 때 value값으로 userId만 적재하는 것이 아닌 총액도 같이 적재하려고 하는데 괜찮은지

## 질문
### 동시성 제어 관련 질문 (A)
#### A-1) 애플리케이션 레벨에서의 동시성 제어 관련
동시성을 제어하는 방법에는 애플리케이션 레벨에서 동기화 처리를 하거나, 데이터베이스 레벨에서 락을 걸어서 제어하는 방법이 있다고 알고 있습니다.
애플리케이션 레벨의 동기화 처리(synchronized / ReentrantLock/Atomic 연산)는 분산 환경일 경우 다른 인스턴스에서 수행되는 쓰레드까지 제어할 수 없으니 한계가 있는 것 같습니다. 따라서 단일 인스턴스 환경이라면 사용해도 되겠지만, 그게 아니라면 파일 업로드와 같은 동일 메모리 영역 내에서 여러 쓰레드가 병렬 작업하여 효율적으로 처리할 수 있게 할 때에 주로 사용하는 것이 적절할까요? 

#### A-2) 데이터베이스 레벨에서의 동시성 제어 관련
분산 환경에서는 데이터베이스 레벨의 동기화 처리(비관적 락/낙관적 락)를 적용할 수 있는데,
이 경우 DB가 샤딩되어 있는 등 단일 인스턴스가 아니면 좀 처리하기 까다롭기도 하고, DB I/O가 무겁기 때문에 성능을 우선적으로 생각해야 할 경우에는 분산락을 적용한다고 알고 있습니다.
분산락의 적용 사례가 적절할까요? 

개인적인 생각으로는 금전적 손실로 이어질 수 있는 중요한 로직은 성능을 좀 포기하더라도 데이터베이스 레벨에서 락을 거는 등 확실하고 안전하게 수행해야 할 거 같고, 이외에는 성능을 우선시 한다면 분산락을 적용하면 어떨까 생각했습니다.
그런데 실무에서는 분산락이 가장 낮은 날림 처리의 락이라 비유하여 안전성이 그닥 높지 않다고 합니다.
또한 Redis 서버가 SPOF가 될 수도 있기도 하고 여러 트레이드 오프가 존재하는 것 같습니다.
제일 안전한 건 애플리케이션, 트랜잭션, 분산락 다 적용시키는 게 맞을 수 있겠는데 실무에서는 어떻게 하는 것을 권장하나요?

---

### 멱등성 관련 질문 (B)
#### B-1) 멱등성 처리 전략 관련
멱등성을 처리할 때 대표적으로 3가지 전략을 고민해봤습니다.
1. 즉시 예외 반환
    - 클라이언트/서버 모두 재시도 로직 구현X
    - 락 획득 실패 시 저장되어 있는 멱등성 키 정보를 가져오지 않고 바로 예외 발생
2. 서버 결과 저장 + 클라이언트 재시도
    - 서버는 성공과 비즈니스 로직이 실패한 경우 해당 결과를 저장함(DB or 캐싱)
    - 락 획득 실패 시 저장되어 있는 멱등성 키 정보를 통해 결과를 조회함
    - 이때 만약 결과가 PROCESSING이면 다시 클라이언트로 예외를 던지고 재시도 수행 / SUCCESS나 FAILED라면 저장된 결과 반환
3. 서버에서 재시도까지 수행
    - 락 획득 실패 시 저장되어 있는 멱등성 키 정보를 조회하는데, 결과 상태에 관련없이 서버측에서 계속 재시도를 수행함

1번은 멱등성 원칙에는 위배되지만, 가장 성능도 우세해서 좋지 않을까라고 생각해봤는데 실제로는 2번 방식을 매우 권장하고, 그렇게 적용하는 것 같더라고요. 실무에서는 어떻게 접근해야 할지 좀 고민됩니다.
그리고 이 멱등성을 적용하는 기준이 금전적인 손해가 오갈 수 있는 곳에 100% 적용하는 건 기본이고, 이외에도 서버 리소스를 생성할 때 중복으로 생성될 수 있는 경우에 적용하는 게 맞을까요?

#### B-2) Redis로 멱등성 구현할 때 Atomic 연산 vs 분산락 관련
AI 답변은 분산락을 적용하라고 하는데, Redisson의 분산락은 value값으로 UUID+ThreadId를 조합해서 value값으로 적재하는 거로 알고 있습니다.
그런데 저는 **“멱등성은 멱등성 키값을 기준으로 락여부를 파악하니, value값으로 UUID+ThreadId 조합이 굳이 필요할까?”** 라는 생각을 하게 됐습니다.

왜냐하면, 분산락은 락을 해제할 때 현재 쓰레드가 그 권한이 있는지를 판단해야 하기 때문에 UUID + ThreadId 조합을 사용한다고 알고 있는데요 (맞을까요?)
멱등성의 경우 이렇게까지 핸들링 해야 하나 싶긴 합니다.. 그래서 value값으로 UUID+ThreadId를 저장하지 않고, 바로 상태를 갖는 결과 객체를 미리 저장해두면 더 성능적으로 좋지 않을까? 생각이 들었습니다.

그리고 분산락처럼 복잡하게 재시도하는 로직을 구현하지 않고, 단순히 `SET NX` 연산만 적적용해도 괜찮지 않나 생각했습니다.
왜냐하면 원자적 연산을 통해 Redis는 여러 쓰레드의 요청 중 하나만 성공시키기 때문에 나머지는 실패한다고 알고 있기 때문입니다.

반면에 분산락을 사용하게 되면, 분산락을 위한 key값은 value로 UUID+ThreadId를 갖게 되고, 락 획득 후 별도로 멱등성 키에 대한 결과 객체를 저장해야 하여 비효율적이지 않을까 생각합니다.
또한 분산락의 경우 보통 waitTime을 설정하여 대기 및 재시도를 수행하기도 하는데, 이는 1번 질문의 3번 케이스(서버에서 재시도까지 수행)이 되어버려서 서버의 리소스를 많이 낭비할 거라 생각합니다. (쓰레드는 한정적이니깐요)

따라서 저는 멱등성 구현할 때 분산락을 적용하기 보다는 단순히 원자적 연산으로만 적용해도 충분하지 않을까 싶긴 한데, 아직 실무적인 경험이 없다보니 지향/권장되는 방법인지는 판단이 서질 않습니다. 피드백 부탁드립니다.

---

### 분산락 관련 질문 (C)
#### C-1) 실제 RedLock 알고리즘 구현 방법 관련
아무래도 학습용으로 개발하다보니, 실제 분산락을 적용했지만 Redis를 단일 인스턴스로만 구성했습니다.
실제로 RedLock 알고리즘을 통한 분산락을 적용하기 위해서는 여러 Redis 인스턴스를 구성해야 한다고 알고 있습니다.
또한 구성되는 인스턴스의 수는 홀수여야 하며(최소 3대, 권장 5대), 이 중 다수결로 많이 락을 획득한 쓰레드가 점유권을 갖는 것으로 알고 있습니다.
아직 다른 코드들도 리팩토링해야 할 부분이 너무 많아서, 나중에 한 번 적용해보려 하는데, 아래와 같은 흐름으로 코드를 작성하면 될까요?
```java
1. 여러 Redis 인스턴스 Connection 목록을 기준으로
2. lock_key를 통해 redissonClient.getLock() 및 tryLock()을 통해 락 획득 시도
3. tryLock()으로 부터 반환받은 true 값의 개수가 목록 기준 /2보다 클 경우 해당 쓰레드에서 비즈니스 로직 수행
```

#### C-2) 분산락 중첩 관련
예시로 비유할 케이스가 생각나지 않아 A로직, B로직이라 정의하겠습니다.
특정 기능을 수행할 때, A로직과 B로직이 하나의 트랜잭션에서 수행되어야 한다고 해보겠습니다.
A로직과 B로직 각각 동시성을 제어해야 하고, 분산환경에서 성능을 중요시한다고 생각하여 분산락을 적용시킨다고 해보겠습니다.
이때 A로직과 B로직의 락 점유 기준 데이터 형식이 다르다고 할 때, A로직에 `lock:A:` 형식으로 분산락을 걸고
B로직도 `lock:B:` 형식으로 분산락을 걸 때, A로직 내부에 B로직이 포함되어 있어서 중첩된 분산락을 갖는 구조가 정상적인 걸까요?
AI에게 물어보니 데드락이나 성능 저하가 발생될 수 있다고 하여 주의해야 한다고 하는데, 
이 자체가 정상적일 수는 있다고 합니다. 단 안전하진 않을 수 있다는데.. 너무 말장난 같게 느껴져서 실무적인 사례로 피드백을 받아보고 싶습니다.

#### C-3) 대기열 관련
분산락을 구현하면서 느꼈던 게, 요청의 대한 순서를 보장하지 않는다 생각했습니다.
이를테면, 사용자1에서 사용자5가 거의 요청하여 쓰레드 1~5가 발생한다고 했을 때, 가장 늦게 요청한 사용자5의 쓰레드가 가장 먼저 락을 획득할 수도 있다고 생각이 들었습니다. (네트워크 지연문제 등으로)
그래서 실제로 대기열을 사용하여 요청이 들어온 순서대로 락을 획득할 수 있게 하기 위해서 사용하는 건가요?

---

### DDD 관련 질문 (D)
#### D-1) Bounded Context와 Aggregate Root 선정 기준
제가 이해한 것은 Bounded Context는 도메인이 문맥적으로 동일하게 사용되는 범위 전체를 의미한다고 생각합니다. 이를 프로그래밍/프로젝트로 구분하자면 가장 최상위 도메인별 패키지가 된다고 생각해서 구분하고 있습니다.
그리고 Aggregate Root는 어떻게 선정해야 하는지도 모르겠습니다.
설명으로는**”트랜잭션 단위로 일관성을 유지해야 하는 도메인 객체들의 집합 중 대표가 되는 엔티티”**라고 합니다.
위 두 가지(BC, AR)를 실무적으로 어떻게 판단하고 분리하고 정립하는지 피드백이 필요합니다.

#### D-2) Aggregate 조회 시 지연로딩/즉시로딩 관련
DDD의 원칙은 Aggregate Member(Child Entity)에 접근할 때 무조건 Aggregate Root를 통해서 접근해야 한다고 합니다.
현재 프로젝트에서 AR - AM 구조는 다음과 같습니다
- Concert - ConcertSchedule
- Venue - VenueSeat
- Reservation - ReservationDetail

그런데 여기서 ConcertSchedule, VenueSeat, ReservationDetail 정보만 필요할 수도 있을 텐데,
그래도 그때마다 Aggregate Root까지 같이 조회해야 하나 싶습니다.

찾아본 바로는 CQRS 전략을 도입하게 되면, DDD 원칙상에는 위배되지만 실무적으로 수정될 일이 아예 없다는 가정하에 불변식을 유지 안 해도 되니 Query는 Aggregate Member(Child Entity)에 바로 접근할 수 있다고 합니다.
다만 Command의 경우 데이터 상태를 변경하기 때문에 불변식 유지가 필수라고 해서 Aggregate Root까지 같이 조회해야 한다고 하는데.. 맞을까요?

그러면 관련된 모든 정보를 다 loading시켜야 하는 건지도 궁금합니다. (업데이트 안 하는 정보인데도 로딩해야 하는지..)
- Aggregate Root만 업데이트 → Aggregate Root 엔터티만 조회
- Aggregate Member(Child Entity)만 업데이트할 경우
    - Aggregate Root 모든/필수 정보 + Child Entity 모든/필수 정보 조합 중 어떻게 조합해서 조회해야 하는지

#### D-3) Aggregate Child도 RepositoryPort를 구현해도 되는지
위 2번 대답이 YES일 경우, DDD 원칙은 Aggregate Root 접근이 원칙이라 했지만, 읽기 작업의 경우에는 Aggregate Member에 바로 접근할 수 있다고 하는데
그러면 Aggregate Member 전용 RepositoryPort를 구현해서 usecase에서 사용해도 되나요?
아니면 Aggregate Root의 Repository만 두고, 그 내부 메서드에서 Aggregate Member를 조회하는 메서드를 구현해야 하는 건지 궁금합니다.
```java
public class ExampleService implements ExampleUseCase {
		private final AggregateRootRepositoryPort aggregateRootRepositoryPort;
		private final ChildEntityRepositoryPort childEntityRepositoryPort; // 가능?
}
```

#### D-4) Aggregate 조회 시 JOIN 전략 관련
2번 질문에서 나아간 개념인데, Aggregate Root와 그 하위 엔터티들을 조회할 때 개별적으로 쿼리를 날리면 매우 비효율적이라고 생각합니다.
그래서 JOIN을 통해 연관데이터를 한번에 가져올 수 있는 건 한 번에 가져오는 게 좋다고 생각하는데,
AI 답변으로는 
- **기본은 분리 조회**로 시작
- **성능 병목이 실제 발생**하면 JOIN 고려
- **UseCase별로 최적화된 조회 메서드** 제공
라고 합니다.

즉, 기본적으로 개별 조회 로직을 구현하고, Aggregate를 구성할 때 각각 개별적으로 조회해서 애플리케이션 레벨에서 조립하라는데 이게 실무적으로도 맞는 걸까요?

개별적으로 조회하면 책임은 많이 분리되겠지만, Network I/O, DB I/O등 성능저하를 유발하고 불필요한 트래픽을 발생시킨다고 생각해서, JOIN이 필요한 경우는 적극 활용하는 게 좋지 않을까 생각을 했습니다.
그래서 Concert에도 `findById`, ConcertSchedule에도 `findById`를 구현하고(이는 Query전용),
만약 전체 Aggregate를 구성해야 한다면 내부적으로 `Concert.findById`를 호출하고 `ConcertSchedule.findById`를 호출하는 것이 아닌, Concert에 `findByIdWithSchedules`와 같은 메서드를 별도로 구현하려고 하는데 이 부분에 대해서도 실무적인 피드백을 주신다면 감사하겠습니다.

#### D-5) Bounded Context 간의 JOIN 관련
같은 Bounded Context 내에 있는 데이터는 JOIN해도 괜찮은 거로 알고 있으나, 다른 Bounded Context영역의 테이블까지 JOIN하면 안 되는 것으로 알고 있습니다.
그래서 여러 Bounded Context 데이터 조합이 필요하다면, 각각의 Bounded Context 별로 조회해서 데이터를 애플리케이션 레벨에서 조합해야 하는 게 맞을까요?
(간단하게 생각해봐도 MSA 전환 시 분리된 데이터베이스에서 JOIN이 불가능한 것도 한 예시라 보여집니다.)

위 대답이 YES라면,
매 조회마다 이러면 되게 부담스러울 테니, 알아본 바로는 CQRS에서 Read Model을 전용적으로 만든다고 합니다.
그래서 이 Read Model을 RDBMS로 둘 수도 있고, 캐싱 데이터 목적이라 보통 MongoDB로 구성하는 경우가 많다고 알고 있습니다.
근데 생각해보면 모든 요청마다 이렇게 Read Model로 만드는 건 정합성 관리도 해야 하고 좀 관리할 포인트가 늘어나 복잡해질 텐데 우선 제 지식이 맞는지 확신이 100% 들진 않지만, 실무에서는 혹시 어떤 기준으로 적용을 할까요?
"각 BC마다 조회해서 애플리케이션 레벨에서 조합"으로 먼저 구현하고 조회 트래픽이 많이 발생한다고 하면 별도 read model로 따로 빼는 건지.. (그전까지는 로직이 비효율적이라도 요청이 많이 발생하지 않는 기능이면 그대로 사용하는 건지..) 
이 부분에 대해서도 실무적인 피드백을 주신다면 감사하겠습니다.

#### D-6) 다른 BC 데이터를 ACL로 조회할 때, 어떻게 현재 BC에 데이터를 구성해야 하는지
현재 프로젝트에서는 Concert에서 Venue 정보가 필요로 합니다.
콘서트 상세 조회 시 공연장명을 같이 응답해주기 위해서예요.
물론 CQRS를 쓰면, Read Model을 미리 구성해두고 그거를 조회하면 된다고 생각이 들긴 합니다.
단, 자주 조회되는 요청이 아니라고 할 경우(콘서트 상세조회는 실제로 자주 조회 요청이 되겠지만, 예시로요) 굳이 Read Model로 만들 필요가 없지 않을까 생각이 듭니다.
그래서 결국 Application 레벨에서 여러 BC 데이터들을 조합해서 사용자에게 응답을 내려줘야 한다고 생각되는데,
이때 Concert BC에서 ACL로 Venue BC 정보를 조회할 때, 내부BC에 맞는 데이터 형식으로 변환을 해줘야 하잖아요? 아래 코드처럼요
- 이것도 물론 MSA로 REST API 통신을 하면 GetVenueResult를 직접 의존하지 않아도 된다 생각합니다.
- 그러나 현재 모놀리식 기반의 헥사고날이므로, ACL 시 저렇게 의존하도록 했습니다. (괜찮다고 알고 있는데 맞겠죠?)
```java
@Component
@RequiredArgsConstructor
public class ConcertVenueQueryAdapter implements ConcertVenueQueryPort {

    private final GetVenueUseCase getVenueUseCase;

    @Override
    public ConcertVenueSnapShot findVenueById(Long venueId) {
        GetVenueResult result = getVenueUseCase.execute(venueId); // GetVenueResult는 venues/application/dto/result
        return ConcertVenueSnapShot.builder() // ConcertVenueSnapShot은 concerts/domain/external
                .id(result.id())
                .name(result.name())
                .totalSeats(result.totalSeats())
                .build();
    }
}
```
이때 궁금한 게 외부 데이터 객체의 필드 범위가 궁금합니다.
예를 들어 현재 Concert 상세 조회는 공연장명만 필요로해서 Long venueId, String venueName 두 가지 필드만 SnapShot에 구성되어 있는데, 나중에 Concert 공연장 총좌석 조회라든지, 주차장 조회라든지.. 예를들어 Venue의 다른 데이터 필드들도 필요로하는 경우가 있을 텐데
그때마다 1:1 매핑해서 ConcertParkingLotSnapShot, ConcertVenueSeatsCountSnapShot... 뭐 이런식으로 둬야 할지..
아니면 그냥 통합 필드를 하나의 객체로 두고, (Venue Domain Entity와 유사하게) 조회는 한번에 다 하되, Concert BC에서 필요로하는 데이터들만 꺼내서 조합해서 쓰는 게 맞는지 궁금합니다.
즉, ConcertVenueSnapShot에 id, name, description, address, List<SeatSnapShot> seats... 이런식으로 구성하는 게 맞는지 궁금합니다.

#### D-7) 6번의 답이 통합 객체로 관리하는 게 맞다면
일반적으로 Venue BC에서 제공되는 공연장 조회 기능을 Concert BC에서 공연장 이름만 필요하다라고해서 새로 만들어둘 수는 없잖아요? 많이 쓰인다면 모를까, MSA의 경우 서로 분리된 서비스 구분할 텐데
그럼 Concert BC에서는 Venue BC 데이터 중 공연장 이름만 필요하더라도, 공연장 상세 정보 전체를 조회하여 그 중에서 이름만 추출하도록 구성하는 것이 적절할까요?

---

### 헥사고날 아키텍처 관련 질문 (E)
#### E-1) 헥사고날 + JPA + 낙관적 락 적용
https://medium.com/@rlaeorua369/헥사고날-아키텍처를-설계하며-마주한-현실적인-고민들-6142ddb53bbb
이 글처럼, 헥사고날 아키텍처를 사용하면 영속성 컨텍스트가 유지되지 않기 때문에 JPA의 이점을 상당수 못 활용하는 것 같습니다.

이번에 포인트 충전에 낙관적 락을 적용시켰는데, 아래 코드처럼 코딩하니 낙관적 락이 적용되지 않았었습니다.
```java
@Override
public Point save(Point point) {
    PointJpaEntity entity = PointJpaEntity.from(point);
    PointJpaEntity result = pointJpaRepository.save(entity);
    return Point.create(
            result.getUserId(),
            Amount.of(result.getAmount()),
            result.getUpdatedAt()
    );
}
```

당연하게도, 영속성 컨텍스트를 추적하는 게 아닌 새 JPA Entity를 만들기 때문에 version이 추적 안 되는 거였습니다.
이를 해결하기 위해서 Domain Entity에도 version 필드를 두고, 업데이트 시 아래처럼 구현했는데 적절하게 구현한 게 맞을까요?
```java
@Override
// Domain Entity를 기반으로 새 JPA Entity를 만들어서(from) save할 경우 version 추적이 안됨
// 따라서 version 정보가 있을 경우 비효율적일 수 있지만 다시 findBy()로 조회한 후 수정하는 방식으로 변경
public Point save(Point point) {
    if (point.getVersion() == null) {
        // 새로운 엔티티
        PointJpaEntity entity = PointJpaEntity.from(point);
        PointJpaEntity result = pointJpaRepository.save(entity);
        return Point.createWithVersion(
                result.getUserId(),
                Amount.of(result.getAmount()),
                result.getUpdatedAt(),
                result.getVersion()
        );
    } else {
        // 기존 엔티티 업데이트
        PointJpaEntity entity = pointJpaRepository.findById(point.getUserId())
                .orElseThrow(() -> new NoSuchElementException("존재하지 않는 회원입니다."));

        // Domain의 계산 결과를 JPA Entity에 적용
        // 도메인 엔터티에서 이미 수행했으므로 해당 메서드에서 += 수행하지 않아도 됨
        entity.updateAmount(point.getAmount().value(), point.getUpdatedAt());
        PointJpaEntity result = pointJpaRepository.save(entity);
        return Point.createWithVersion(
                result.getUserId(),
                Amount.of(result.getAmount()),
                result.getUpdatedAt(),
                result.getVersion()
        );
    }
}
```

#### E-2) 헥사고날 아키텍처에서 공통 기능을 모듈화하게 된다면 어떤식으로 관리하고, 어떻게 모듈화를 해야 할까요?
예를 들어 분산락 관련해서도 lock-key와 value를 전달받으면 동일한 wait time, lease time으로 LockManager 기능을 제공해줄 수 있지 않을까 생각해봤습니다.
그런데 shared에는 구현체가 있으면 안되고, vo나 entity 같은 것들이 있어야 한다고 해서 어떻게 관리해야 하나 궁금합니다.

#### E-3) 패키지 및 컨벤션 관련
헥사고날 아키텍처를 적용하면서 느낀 불편함이, 컨벤션이 딱히 정해지지 않아서 많이 애먹었습니다.
생성자 전략도 어떤 거는 팩토리 메서드를 사용하고, 어떤 거는 builder패턴을 사용하고
이런 네이밍이나 구조화는 정답이 정말 없긴 한데.. 뭔가 코치님께서는 사용하기 편하거나 재직 중이신 곳에서 관례적으로 사용하는 것들이 궁금합니다.

우선 제 기준에서는 다음과 같이 가이드라인을 세워봤습니다. 그냥 적절한지만 봐주시면 감사하겠습니다!!
[Application 계층]
- DTO (Command/Query/Result)
    - record 파일 사용
    - builder 패턴으로 생성

[Domain 계층]
- Domain Entity
    - class 파일 사용
    - 외부 생성 시 팩토리 메서드 사용 (create, createWithSchedules 등)
- VO
    - record 파일 사용
    - 값 객체는 무조건 of() 팩토리 메서드 사용

[Infra 계층]
- 무조건 Optional로 반환 / 예외 처리는 Application에서 수행
- (현재 프로젝트에는 적용시키지 못했으나) mapper 사용하여 JPA에 순수성을 지키도록 함
- 즉 Entity 내에 from()이나 toDomain() 같은 메서드 금지